### PR TITLE
Switch to console.error

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class WebpackFixStyleOnlyEntriesPlugin {
           );
         if (isStyleOnly) {
           if (!this.options.silent) {
-            console.log(
+            console.error(
               "webpack-fix-style-only-entries: removing js from style only module: " +
                 file
             );


### PR DESCRIPTION
As described in the https://github.com/webpack/webpack-cli/issues/737 `console.log` corrupts the final json file provided by the `--json` option.
They fixed this by switching to `console.error` as seen in this pull request: https://github.com/webpack/webpack-cli/pull/744

I believe the same thing should be done here, since I'm having this line in my json file:

```
webpack-fix-style-only-entries: removing js from style only module: javascripts/appStyles-78c8323b9a1489caa5b8.js
```