### PR TITLE
Support splitted chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,14 @@ class WebpackFixStyleOnlyEntriesPlugin {
     compiler.hooks.compilation.tap(NAME, compilation => {
       compilation.hooks.chunkAsset.tap(NAME, (chunk, file) => {
         if (!file.endsWith(".js") && !file.endsWith(".mjs")) return;
-        if (!chunk.hasEntryModule()) return;
 
-        const rawResources = collectEntryResources(chunk.entryModule);
+        const modules = chunk.hasEntryModule()
+          ? [chunk.entryModule]
+          : Array.from(chunk._modules.values());
+        const rawResources = Array.prototype.concat.apply(
+          [],
+          modules.map(collectEntryResources)
+        );
         const resources = this.options.ignore
           ? rawResources.filter(r => !r.match(this.options.ignore))
           : rawResources;


### PR DESCRIPTION
Splitted chunks don't have a main module.

Example that produce splitted chunk for both JS (unwanted) and CSS without that patch:

```js
const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
const MiniCssExtractPlugin = require("mini-css-extract-plugin");

module.export = {
  entry: {
    page1: [
      "common.css",
      "page1.css",
      "page1.js"
    ],
    page2: [
      "common.css",
      "page2.css",
      "page2.js"
    ],
    page3: [
      "page3.css",
      "page3.js"
    ]
  },
  module: {
    rules: [{
      test: /\.css$/,
      use: [MiniCssExtractPlugin.loader, 'css-loader']
    }]
  },
  optimization: {
    splitChunks: {
      cacheGroups: {
        common: {
          test: /common\.css/,
          minChunks: 2,
        }
      }
    }
  },
  plugins: [
    new FixStyleOnlyEntriesPlugin(),
    new MiniCssExtractPlugin()
  ]
}
```