### PR TITLE
Prevent arbitrary files deletion when using Webpack with multi configurations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-fix-style-only-entries",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/cases/multi-configuration/expected.json
+++ b/test/cases/multi-configuration/expected.json
@@ -1,0 +1,1 @@
+["scriptA.js", "styleA.css", "scriptB.js", "styleB.css"]

--- a/test/cases/multi-configuration/foo.js
+++ b/test/cases/multi-configuration/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/cases/multi-configuration/script.js
+++ b/test/cases/multi-configuration/script.js
@@ -1,0 +1,2 @@
+const foo = require('./foo.js');
+console.log(foo);

--- a/test/cases/multi-configuration/style.css
+++ b/test/cases/multi-configuration/style.css
@@ -1,0 +1,5 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+}

--- a/test/cases/multi-configuration/webpack.config.js
+++ b/test/cases/multi-configuration/webpack.config.js
@@ -1,0 +1,33 @@
+const WebpackFixStyleOnlyEntries = require("../../../index.js");
+
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+const baseConfig = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
+      },
+    ],
+  },
+  plugins: [
+    new WebpackFixStyleOnlyEntries({ silent: true }),
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+  ],
+};
+
+console.log(__dirname + "../outputs");
+
+module.exports = [
+  {
+    entry: { scriptA: "./script.js", styleA: "./style.css" },
+    ...baseConfig,
+  },
+  {
+    entry: { styleB: "./style.css", scriptB: "./script.js" },
+    ...baseConfig,
+  },
+];

--- a/test/webpack-integration.test.js
+++ b/test/webpack-integration.test.js
@@ -35,7 +35,13 @@ describe("Webpack Integration Tests", () => {
             path: outputDirectory,
           },
         };
-        const config = merge(configDefaults, baseConfig);
+
+        let config;
+        if (Array.isArray(baseConfig)) {
+          config = baseConfig.map(c => merge(configDefaults, c));
+        } else {
+          config = merge(configDefaults, baseConfig);
+        }
 
         webpack(config, (err, stats) => {
           if (err) return done(err);


### PR DESCRIPTION
In some cases when running Webpack with multiple configurations (Webpack config file exports an array of configurations), arbitrary files are deleted and empty extra JS files are not.

This is due to the internal plugin cache system. It is based on module indexes, but they are not unique by compilation phase.

The proposed fix implements a dedicated cache for each compilation.
(note that it is no longer necessary to clean the cache in "watch mode")

Fixes #37 