### PR TITLE
fix: [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] webpack5 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ class WebpackFixStyleOnlyEntriesPlugin {
                 file
             );
           }
-          chunk.files = chunk.files.filter(f => f != file);
+          const filtered = [...chunk.files].filter(f => f != file);
+          chunk.files = (chunk.files instanceof Set) ? new Set(filtered) : filtered;
           delete compilation.assets[file];
         }
       });


### PR DESCRIPTION
> (node:7590) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'filter' is deprecated)
